### PR TITLE
Fix incorrect type for CardTitle ref

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -30,7 +30,7 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h3


### PR DESCRIPTION
## Summary
- fix the ref element type for `CardTitle`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b9b8e57c8321bb9ea1f45f2d89fe